### PR TITLE
Fixed typo falg -> flag in both versions

### DIFF
--- a/v2/server-ip/data/ip/ip.html
+++ b/v2/server-ip/data/ip/ip.html
@@ -44,7 +44,7 @@
   </head>
   <body>
     <style type="text/css" id="css"></style>
-    <img src="loading.gif" width=16 title="Drag the falg and slowly move it to change position"><a target="_blank" href="#">127.0.0.1</a><img src="close.svg" width=16 data-cmd="close-me">
+    <img src="loading.gif" width=16 title="Drag the flag and slowly move it to change position"><a target="_blank" href="#">127.0.0.1</a><img src="close.svg" width=16 data-cmd="close-me">
     <script src="ip.js"></script>
   </body>
 </html>

--- a/v3/server-ip/data/ip/ip.html
+++ b/v3/server-ip/data/ip/ip.html
@@ -44,7 +44,7 @@
   </head>
   <body>
     <style type="text/css" id="css"></style>
-    <img src="loading.gif" width=16 title="Drag the falg and slowly move it to change position"><a target="_blank" href="#">127.0.0.1</a><img src="close.svg" width=16 data-cmd="close-me">
+    <img src="loading.gif" width=16 title="Drag the flag and slowly move it to change position"><a target="_blank" href="#">127.0.0.1</a><img src="close.svg" width=16 data-cmd="close-me">
     <script src="ip.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The HTML code had a typo `falg` instead of `flag`. This PR fixes that.