### PR TITLE
Update worker.js - Disable redirects

### DIFF
--- a/v3/country-flags/worker.js
+++ b/v3/country-flags/worker.js
@@ -294,6 +294,7 @@ const xDNS = href => new Promise((resolve, reject) => {
     cache: 'no-cache',
     // https://github.com/andy-portmen/country-flags/issues/79#issuecomment-1186255111
     credentials: 'omit',
+    redirect: 'manual',
     signal
   }).then(r => r.text()).catch(e => done(null, e));
 });


### PR DESCRIPTION
If a website redirects with 301/302 the fetch follows until it reaches the destination

We have a specific case where it redirects forever to itself until the client gets rejected from the website