### PR TITLE
Going from `Almost Standards Mode` to `Standards Mode` Fixes #97

### DIFF
--- a/v2/server-ip/data/ip/ip.html
+++ b/v2/server-ip/data/ip/ip.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <style>

--- a/v3/server-ip/data/ip/ip.html
+++ b/v3/server-ip/data/ip/ip.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <style>


### PR DESCRIPTION
This should fix the issue of a warning in Firefox as detailed in issue #97.